### PR TITLE
Implement critical fail rolls

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -66,7 +66,7 @@
 "CPRED.degrade": "Degradation",
 "CPRED.demolitions": "Demolitions",
 "CPRED.dex": "DEX",
-"CPRED.dierollcommandhint": "Defaults to d10xo10 (explode once). Adjust to d10x10 if you want infininte explosion or to d10 to remove exploding completely. Use other options with caution.",
+"CPRED.dierollcommandhint": "Defaults to dpixo1xo10 (explode once). Adjust to dpix1x10 if you want infininte explosion or to d10 to remove exploding completely. Use other options with caution.",
 "CPRED.dierollcommandname": "Die roll command for rolls.",
 "CPRED.disabled": "Disabled",
 "CPRED.drivelandvehicle": "Drive Land Vehicle",

--- a/module/cyberpunkred.js
+++ b/module/cyberpunkred.js
@@ -15,6 +15,9 @@ import {
   cyberpunkredItemSheet
 } from "./item-sheet.js";
 import {
+  cyberpunkredDie
+} from "./die.js";
+import {
   registerSystemSettings
 } from "./settings.js";
 import {
@@ -75,6 +78,8 @@ Hooks.once('init', async function () {
     makeDefault: true
   });
 
+  _cprLog(`Register cyberpunkred die`);
+  CONFIG.Dice.terms["p"] = cyberpunkredDie;
 
   _cprLog(`Register Handlebars`);
 

--- a/module/die.js
+++ b/module/die.js
@@ -1,0 +1,64 @@
+import {
+    _cprLog
+  } from "./tools.js";
+
+/**
+ * Extend the Die to handle critical failures (implemented by @JDW on the foundryvtt discord)
+ * @extends {Die}
+ */
+export class cyberpunkredDie extends Die {
+    constructor(termData) {
+        termData.faces=10;
+        super(termData);
+    }
+    invertExplode(modifier, { recursive = true } = {}) {
+
+        // Match the explode or "explode once" modifier
+        const rgx = /[iI][xX][oO]?([0-9]+)?([<>=]+)?([0-9]+)?/;
+        const match = modifier.match(rgx);
+        if (!match) return this;
+        let [max, comparison, target] = match.slice(1);
+
+        // If no comparison was set, treat the max as the target
+        if (!comparison) {
+            target = max;
+            max = null;
+        }
+
+        // Determine threshold values
+        max = parseInt(max) || null;
+        target = parseInt(target) || this.faces;
+        comparison = comparison || "=";
+
+        // Recursively explode until there are no remaining results to explode
+        let checked = 0;
+        let initial = this.results.length;
+        while (checked < this.results.length) {
+            let r = this.results[checked];
+            checked++;
+            if (!r.active) continue;
+
+            // Maybe we have run out of explosions
+            if ((max !== null) && (max <= 0)) break;
+
+            // Determine whether to explode the result and roll again!
+            if (DiceTerm.compareResult(r.result, comparison, target)) {
+                r.exploded = true;
+                this.roll();
+                if (max !== null) max -= 1;
+                DiceTerm._applyDeduct([this.results[this.results.length-1]],"<=", 10,{invertFailure:true});
+            }
+
+            // Limit recursion if it's a "small explode"
+            if (!recursive && (checked >= initial)) checked = this.results.length;
+            if (checked > 1000) throw new Error("Maximum recursion depth for exploding dice roll exceeded");
+        }
+    }
+
+    invertExplodeOnce(modifier) {
+        return this.invertExplode(modifier, { recursive: false });
+    }
+}
+cyberpunkredDie.MODIFIERS = Die.MODIFIERS;
+cyberpunkredDie.MODIFIERS.ix = "invertExplode";
+cyberpunkredDie.MODIFIERS.ixo = "invertExplodeOnce";

--- a/module/settings.js
+++ b/module/settings.js
@@ -20,7 +20,7 @@ export const registerSystemSettings = function() {
     hint: "CPRED.dierollcommandhint",
     scope: "world",
     config: true,
-    default: "d10xo10",
+    default: "dpixo1xo10",
     type: String
   });
 	


### PR DESCRIPTION
This implements critical failures in a similar manner to critical success rolls. I had to extend the built-in `Die` class because of some limitations on overriding the "d" term, so you now roll a `dp` die instead of a d10. You can handle "imploding" dice by adding an `ix` modifier to the roll (e.g., `dpixo1` would implode on a roll of 1). The default roll in settings.js has been updated to handle both imploding and exploding dice (crit success and crit fails):

```
default: "dpixo1xo10",
```

The chat messages properly show and color the rerolled dice (with crit fails being red) to make it easy to follow the formula in chat:

![cprdie](https://user-images.githubusercontent.com/12201350/100493752-09f35580-3132-11eb-9100-2cd6e56be773.png)