### PR TITLE
check number of 6s in damage rolls for critical injuries (#51)

### DIFF
--- a/css/cyberpunkred.css
+++ b/css/cyberpunkred.css
@@ -6,6 +6,7 @@
   --cpr-red-color: #700000; /* var(--cpr-red-color) */
   --cpr-light-bak-color: #FFFFFF; /* var(--cpr-light-bak-color) */
   --cpr-app-bak-color: rgba(200,200,200,1.00); /* var(--cpr-app-bak-color) */
+  --cpr-green-color: #18520b; /* var(--cpr-green-color) */
   --cpr-default-text-size: .90em;
   --cpr-default-small-text-size: .80em;
 }
@@ -45,6 +46,10 @@
 
 .cpr-roll-showtagslink {
   font-size: .5em;
+}
+
+.cpr-roll-crit-success {
+  color: var(--cpr-green-color);
 }
 
 /* Rolls */

--- a/module/actor.js
+++ b/module/actor.js
@@ -749,6 +749,16 @@ export class cyberpunkredActor extends Actor {
       // Do the roll.
       let roll = new Roll(`${formula}`);
       roll.roll();
+      if (cmdCmd === "_RollDamage") { // check for critical injuries
+        let sixes = 0;
+        let results = roll.dice[0].results;
+        for (var i = 0; i < results.length; i++) {
+          if (results[i]['result'] === 6) {
+            sixes++;
+          }
+        }
+        // notify user of critical injury somehow
+      }
       // Render it.
       roll.render().then(r => {
         templateData.rollcpr = r;

--- a/module/actor.js
+++ b/module/actor.js
@@ -634,7 +634,7 @@ export class cyberpunkredActor extends Actor {
     }
   }
 
-  isCritInjury(roll) {
+  checkCritInjury(roll) {
     let sixes = 0;
     let results = roll.dice[0].results;
     for (var i = 0; i < results.length; i++) {
@@ -645,11 +645,11 @@ export class cyberpunkredActor extends Actor {
     return sixes >= 2;
   }
 
-  isCritFail(roll) {
+  checkCritFail(roll) {
     return roll.dice[0].results[0]["result"] === 1;
   }
 
-  isCritSuccess(roll) {
+  checkCritSuccess(roll) {
     return roll.dice[0].results[0]["result"] === 10;
   }
 
@@ -770,13 +770,13 @@ export class cyberpunkredActor extends Actor {
       roll.roll();
       if (cmdCmd != "_RollDamage") {
         // Don't check for critical success/failure on damage rolls
-        if (this.isCritFail(roll)) {
+        if (this.checkCritFail(roll)) {
           templateData["critfail"] = "Critical Failure!";
-        } else if (this.isCritSuccess(roll)) {
+        } else if (this.checkCritSuccess(roll)) {
           templateData["critsuccess"] = "Critical Success!";
         }
       }
-      if (cmdCmd === "_RollDamage" && this.isCritInjury(roll)) {
+      if (cmdCmd === "_RollDamage" && this.checkCritInjury(roll)) {
           templateData["critinjury"] = "Critical Injury!";
       }
       // Render it.

--- a/templates/chat/roll-cpr.html
+++ b/templates/chat/roll-cpr.html
@@ -10,6 +10,9 @@
       <input class="cpr-roll-showtagscheck" type="checkbox">
       <div class="cpr-roll-tags"><hr>{{{cprTags tags}}}</div>
     </label>
+    {{#if critinjury}}<div class="cpr-roll-crit-injury">{{{critinjury}}}</div>{{/if}}
+    {{#if critfail}}<div class="cpr-roll-crit-failure">{{{critfail}}}</div>{{/if}}
+    {{#if critsuccess}}<div class="cpr-roll-crit-success">{{{critsuccess}}}</div>{{/if}}
     {{/if}}
-    </div>
+  </div>
 </section>


### PR DESCRIPTION
This starts work on #51 by checking the damage roll results for the number of 6s, which are needed to figure out if you scored a critical injury. I don't actually know how to convey this information to the user, so I've opened this is a draft PR so we can discuss. 

The number of 6's do already show up in the chat log, but it would probably be good to add some custom text to make it easier to read (e.g., **Critical Injury!** in red):
![crit-injuries](https://user-images.githubusercontent.com/12201350/100525340-effc5600-31b7-11eb-8ca9-632901a0e98d.png)

1's and 10's are probably covered by #77 unless I missed a use-case in the rules. 