### PR TITLE
Adjust headshot penalty to -8 for core rules

### DIFF
--- a/lists/modifiers.js
+++ b/lists/modifiers.js
@@ -21,7 +21,7 @@ export const listsModifiers = { // Here begins the object
   },
 
   "modheadshot": {
-    "penalty": -6
+    "penalty": -8
   },
 
   "modunfamiliarequipment": {

--- a/template.json
+++ b/template.json
@@ -721,7 +721,7 @@
           },
 
           "modheadshot": {
-            "penalty": -6,
+            "penalty": -8,
             "checked": false
           },
 


### PR DESCRIPTION
Fixes #81 by adjusting the called shot penalty from -6 to -8 to reflect the change in core rules. Is this OK or is there something I should be doing to maintain backwards compatibility with the JSK?