### PR TITLE
Make sound control buttons visible

### DIFF
--- a/css/cyberpunkred.css
+++ b/css/cyberpunkred.css
@@ -139,6 +139,11 @@
 .sidebar-tab .directory-list .entity {
   background: var(--cpr-app-bak-color);
 }
+
+#playlists li.playlist .sound-control {
+  color: var(--cpr-red-color);
+}
+
 /* Make sure this block has room to edit */
 .cyberpunkred .roomtoedit {
   height: 400px;


### PR DESCRIPTION
This modifies the CSS to make the sound control buttons visible, as they were somehow being set to the background color.