### PR TITLE
update grid distance to 2m

### DIFF
--- a/system.json
+++ b/system.json
@@ -32,7 +32,7 @@
       "path": "lang/de.json"
     }           
   ],
-  "gridDistance": 1,
+  "gridDistance": 2,
   "gridUnits": "m",
   "primaryTokenAttribute": "combatstats.healthpool",
   "secondaryTokenAttribute": "combatstats.luckpool",


### PR DESCRIPTION
This sets the default scene grid distance to 2m in alignment with the CPR core rulebook.