### PR TITLE
Add option to unlink NPC healthpool from BOD stat

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -124,6 +124,7 @@
 "CPRED.lawman": "Lawman",
 "CPRED.legality": "Legality",
 "CPRED.librarysearch": "Library Search",
+"CPRED.linktobod": "Link to BOD",
 "CPRED.lipreading": "Lip Reading",
 "CPRED.localexpert": "Local Expert",
 "CPRED.logheader": "Below is a record of all item mods applied to this character. See Stat Setup tab, item mod column, for totals.",

--- a/module/actor.js
+++ b/module/actor.js
@@ -409,9 +409,13 @@ export class cyberpunkredActor extends Actor {
 
     // Calculate health and luck
     if (allowJSK) {
-      data.combatstats.healthpool.max = data.attributes.body.roll * 5;
+      if (data.settings.prefs.linkBodyToHealth) {
+        data.combatstats.healthpool.max = data.attributes.body.roll * 5;
+      }
     } else {
-      data.combatstats.healthpool.max = 10 + (5 * Math.ceil((data.attributes.body.roll + data.attributes.will.roll) / 2));
+      if (data.settings.prefs.linkBodyToHealth) {
+        data.combatstats.healthpool.max = 10 + (5 * Math.ceil((data.attributes.body.roll + data.attributes.will.roll) / 2));
+      }
     }
 
     if (data.combatstats.healthpool.value > data.combatstats.healthpool.max) {

--- a/module/actor.js
+++ b/module/actor.js
@@ -408,12 +408,10 @@ export class cyberpunkredActor extends Actor {
     //####################
 
     // Calculate health and luck
-    if (allowJSK) {
-      if (data.settings.prefs.linkBodyToHealth) {
+    if (data.settings.prefs.linkBodyToHealth) {
+      if (allowJSK) {
         data.combatstats.healthpool.max = data.attributes.body.roll * 5;
-      }
-    } else {
-      if (data.settings.prefs.linkBodyToHealth) {
+      } else {
         data.combatstats.healthpool.max = 10 + (5 * Math.ceil((data.attributes.body.roll + data.attributes.will.roll) / 2));
       }
     }

--- a/template.json
+++ b/template.json
@@ -802,7 +802,8 @@
             "simpleCombatSetup": true,
             "itemCombatSetup": true,
             "showInventory": true,
-            "automateDamageMod": true
+            "automateDamageMod": true,
+            "linkBodyToHealth": true
           }
         }
       },

--- a/templates/actor/actor-npc-sheet.html
+++ b/templates/actor/actor-npc-sheet.html
@@ -63,8 +63,8 @@
         <div class="combatstats grid grid-2col">
           <div class="resource flex-group-center">
             <label for="data.combatstats.healthpool.value" class="resource-label">{{localize "CPRED.healthpool"}}</label>
-            <input type="checkbox" id="set_linkbodytohealth" name="data.settings.prefs.linkBodyToHealth" {{checked data.settings.prefs.linkBodyToHealth}}>
-            <label for="set_linkbodytohealth">{{localize "CPRED.linktobod"}}</label>
+            <input class="settings" type="checkbox" id="set_linkbodytohealth" name="data.settings.prefs.linkBodyToHealth" {{checked data.settings.prefs.linkBodyToHealth}}>
+            <label class="cpr-center settings-item settings clickable" style="width: 75px;" for="set_linkbodytohealth">{{localize "CPRED.linktobod"}}</label>
             <div class="resource-content flexrow flex-center flex-between">
               <input type="text" name="data.combatstats.healthpool.value" value="{{data.combatstats.healthpool.value}}" data-dtype="Number"/>
               <span> / </span>

--- a/templates/actor/actor-npc-sheet.html
+++ b/templates/actor/actor-npc-sheet.html
@@ -63,6 +63,8 @@
         <div class="combatstats grid grid-2col">
           <div class="resource flex-group-center">
             <label for="data.combatstats.healthpool.value" class="resource-label">{{localize "CPRED.healthpool"}}</label>
+            <input type="checkbox" id="set_linkbodytohealth" name="data.settings.prefs.linkBodyToHealth" {{checked data.settings.prefs.linkBodyToHealth}}>
+            <label for="set_linkbodytohealth">{{localize "CPRED.linktobod"}}</label>
             <div class="resource-content flexrow flex-center flex-between">
               <input type="text" name="data.combatstats.healthpool.value" value="{{data.combatstats.healthpool.value}}" data-dtype="Number"/>
               <span> / </span>


### PR DESCRIPTION
This addresses #50 by adding a boolean to the actor model that specifies whether the healthpool should be linked to the BOD stat or not, which defaults to true. The option can be disabled by deselecting a checkbox on the NPC sheet, at which point the user can manually update the max health total. If you reselect the checkbox it will behave like it did before by automatically adjusting based on the current BOD stat value.

I'm opening this as a draft because the checkbox setup I'm using in `actor-npc-sheet.html` is extremely bad and ugly, and I could use some help or advice on how to present this option in a pretty way (my HTML skills are not very good).