### PR TITLE
Add deathsave roll command to prevent critical success/fail message

### DIFF
--- a/module/actor.js
+++ b/module/actor.js
@@ -692,6 +692,12 @@ export class cyberpunkredActor extends Actor {
         rollObject.tags.push("Manual Formula");
         needsMods = false;
         break;
+      case '_RollDeathSave':
+        rollObject.rollFormula = roll.replace('_RollDeathSave', '');
+        rollObject.tags = new Array();
+        rollObject.tags.push("Manual Formula");
+        needsMods = false;
+        break;
       case '_RollDamage':
         rollObject.rollFormula = roll.replace('_RollDamage', '');
         rollObject.tags = new Array();
@@ -768,8 +774,8 @@ export class cyberpunkredActor extends Actor {
       // Do the roll.
       let roll = new Roll(`${formula}`);
       roll.roll();
-      if (cmdCmd != "_RollDamage") {
-        // Don't check for critical success/failure on damage rolls
+      if (cmdCmd != "_RollDamage" && cmdCmd != "_RollDeathSave") {
+        // Don't check for critical success/failure on damage rolls and death saves
         if (this.checkCritFail(roll)) {
           templateData["critfail"] = "Critical Failure!";
         } else if (this.checkCritSuccess(roll)) {

--- a/module/cyberpunkred.js
+++ b/module/cyberpunkred.js
@@ -108,6 +108,10 @@ Hooks.once('init', async function () {
     return "_RollWithoutMods " + formula;
   });
 
+  Handlebars.registerHelper('RollDeathSave', function (formula) {
+    return "_RollDeathSave " + formula;
+  });
+
   Handlebars.registerHelper('rollDamage', function (formula) {
     return "_RollDamage " + formula;
   });

--- a/templates/actor/actor-character-sheet.html
+++ b/templates/actor/actor-character-sheet.html
@@ -518,7 +518,7 @@
           <h3>{{localize "CPRED.specialrolls"}}</h3>
           <ol class="specialroll-grid">
             <ol class="specialroll-item">
-              <label for="Death Save" data-label='{{localize "CPRED.deathsaverolllabela"}} {{data.attributes.body.roll}}{{localize "CPRED.deathsaverolllabelb"}}' data-roll="{{RollWithoutMods (concat '1d10' '+' data.combatstats.deathsave.penalty) }}" class="rollable deathsave">{{localize "CPRED.deathsave"}} (+{{data.combatstats.deathsave.penalty}})</label>
+              <label for="Death Save" data-label='{{localize "CPRED.deathsaverolllabela"}} {{data.attributes.body.roll}}{{localize "CPRED.deathsaverolllabelb"}}' data-roll="{{RollDeathSave (concat '1d10' '+' data.combatstats.deathsave.penalty) }}" class="rollable deathsave">{{localize "CPRED.deathsave"}} (+{{data.combatstats.deathsave.penalty}})</label>
               <br>
               <li class="flexrow" data-item-id="{{item.id}}"> <i class="alterdeathsave clickable" data-change="-9999">{{localize "CPRED.zero"}}</i> <i class="alterdeathsave clickable" data-change="-1">-1</i> <i class="alterdeathsave clickable" data-change="1">+1</i> </li>
             </ol>


### PR DESCRIPTION
This adds a new roll type (`RollDeathSave`) as a way to prevent showing the Critical Success!/Critical Failure! messages in chat on nat 1 and 10 rolls. The dice were not exploding so the values were correct, but the erroneous messages could confuse users.