### PR TITLE
Fix die denomination and revert hotfix workaround settings

### DIFF
--- a/module/cyberpunkred.js
+++ b/module/cyberpunkred.js
@@ -277,6 +277,5 @@ Hooks.once("ready", function () {
 
   
   ui.notifications.info("CyberpunkRED " + systemDataVersion + " Fully Loaded");
-  ui.notifications.warn("GM - Please see known issues and make sure you set die roller in system settings as appropriate for 0.7.8. To do this, click the gear tab on the top right, then Configure Settings and then System Settings. Set the appropriate CPRED Core Rulebook Handler.", {permanent: true});
 
 });

--- a/module/die-handler.js
+++ b/module/die-handler.js
@@ -11,7 +11,7 @@ export class combinedCPREDDieHandler extends Die {
     termData.faces = 10;
     super(termData);
   }
-
+  static DENOMINATION = "l";
   parseRolls() {
 
     // Determine threshold values

--- a/module/die.js
+++ b/module/die.js
@@ -11,6 +11,7 @@ export class cyberpunkredDie extends Die {
         termData.faces=10;
         super(termData);
     }
+    static DENOMINATION = "p";
     invertExplode(modifier, { recursive = true } = {}) {
 
         // Match the explode or "explode once" modifier

--- a/module/settings.js
+++ b/module/settings.js
@@ -22,8 +22,7 @@ export const registerSystemSettings = function() {
     config: true,
     default: "1dlcpred",
     choices: {
-      "1dlcpred": "CPRED Core Rulebook Handler",
-      "dlcpred": "CPRED Core Rulebook Handler (Choose this if you have the hotfix for 0.7.8)",
+      "1dlcpred": "CPRED Core Rulebook Handler"
     },
     type: String
   });


### PR DESCRIPTION
[Per Atropos](https://gitlab.com/foundrynet/foundryvtt/-/issues/4236#note_465195997), the issues with the 0.7.8 hotfix happened because we didn't define the DENOMINATION on our custom dice. This adds his suggested fix to both the original dp die and the new dl die, and removes the settings and warnings about manual intervention needed if the hotfix was applied. I've confirmed both dice now work both with and without the leading "1".