### PR TITLE
Add alternate method to handle crit explosions correctly

### DIFF
--- a/module/die.js
+++ b/module/die.js
@@ -11,8 +11,8 @@ export class cyberpunkredDie extends Die {
         termData.faces=10;
         super(termData);
     }
+    
     invertExplode(modifier, { recursive = true } = {}) {
-
         // Match the explode or "explode once" modifier
         const rgx = /[iI][xX][oO]?([0-9]+)?([<>=]+)?([0-9]+)?/;
         const match = modifier.match(rgx);
@@ -42,11 +42,13 @@ export class cyberpunkredDie extends Die {
             if ((max !== null) && (max <= 0)) break;
 
             // Determine whether to explode the result and roll again!
-            if (DiceTerm.compareResult(r.result, comparison, target)) {
+            if (DiceTerm.compareResult(r.result, comparison, target) && r.canExplode) {
                 r.exploded = true;
                 this.roll();
+                let newRoll = this.results[this.results.length-1];
+                newRoll.canExplode = false;
                 if (max !== null) max -= 1;
-                DiceTerm._applyDeduct([this.results[this.results.length-1]],"<=", 10,{invertFailure:true});
+                DiceTerm._applyDeduct([newRoll],"<=", 10,{invertFailure:true});
             }
 
             // Limit recursion if it's a "small explode"
@@ -57,6 +59,60 @@ export class cyberpunkredDie extends Die {
 
     invertExplodeOnce(modifier) {
         return this.invertExplode(modifier, { recursive: false });
+    }
+
+    /** @override */
+    explode(modifier, {recursive=true}={}) {
+        // Match the explode or "explode once" modifier
+        const rgx = /[xX][oO]?([0-9]+)?([<>=]+)?([0-9]+)?/;
+        const match = modifier.match(rgx);
+        if ( !match ) return this;
+        let [max, comparison, target] = match.slice(1);
+
+        // If no comparison was set, treat the max as the target
+        if ( !comparison ) {
+            target = max;
+            max = null;
+        }
+
+        // Determine threshold values
+        max = parseInt(max) || null;
+        target = parseInt(target) || this.faces;
+        comparison = comparison || "=";
+
+        // Recursively explode until there are no remaining results to explode
+        let checked = 0;
+        let initial = this.results.length;
+        while ( checked < this.results.length ) {
+            let r = this.results[checked];
+            checked++;
+            if (!r.active) continue;
+            
+            // Maybe we have run out of explosions
+            if ( (max !== null) && (max <= 0) ) break;
+
+            // Determine whether to explode the result and roll again!
+            if ( DiceTerm.compareResult(r.result, comparison, target) && r.canExplode ) {
+                r.exploded = true;
+                this.roll();
+                this.results[this.results.length-1].canExplode = false;
+                if ( max !== null ) max -= 1;
+            }
+            // Limit recursion if it's a "small explode"
+            if ( !recursive && (checked >= initial) ) checked = this.results.length;
+            if ( checked > 1000 ) throw new Error("Maximum recursion depth for exploding dice roll exceeded");
+        }
+    }
+
+    /** @override */
+    roll({minimize=false, maximize=false}={}) {
+        const rand = CONFIG.Dice.randomUniform();
+        let result = Math.ceil(rand * this.faces);
+        if ( minimize ) result = 1;
+        if ( maximize ) result = this.faces;
+        const roll = {result, active: true, canExplode: true};
+        this.results.push(roll);
+        return roll;
     }
 }
 cyberpunkredDie.MODIFIERS = Die.MODIFIERS;


### PR DESCRIPTION
This adds another way to handle explosions of critical rolls, and is hopefully clean enough to be feasible. I've overridden the `roll()` function on our custom `cyberpunkredDie` class to add a `canExplode` property, which defaults to true, and updated the `explode` and `invertExplode` functions to set that property to false on the new result when a roll explodes. Note that this effectively disables infinite explosions, which isn't ideal but in my opinion I think is acceptable since the intent of the Die is to implement the Core Rules, and infinite critical explosions aren't part of the core rules.

I've also tested with Dice So Nice and everything seems to work as intended.