### PR TITLE
hardcode CPR die modifiers

### DIFF
--- a/module/die.js
+++ b/module/die.js
@@ -10,6 +10,7 @@ export class cyberpunkredDie extends Die {
     constructor(termData) {
         termData.faces=10;
         super(termData);
+        this.modifiers = ["ixo1", "xo10"];
     }
     invertExplode(modifier, { recursive = true } = {}) {
 


### PR DESCRIPTION
This hardcodes the standard implosion/explosion modifiers for the custom CPR die. Now, if a user (or the sheet) wants to roll a standard skill check where critical success/failures apply, you can do `/r dp` instead of `/r 1dpixo1xo10` which would be really hard for end users to remember.