### PR TITLE
specify link health to BOD button height

### DIFF
--- a/templates/actor/actor-npc-sheet.html
+++ b/templates/actor/actor-npc-sheet.html
@@ -64,7 +64,7 @@
           <div class="resource flex-group-center">
             <label for="data.combatstats.healthpool.value" class="resource-label">{{localize "CPRED.healthpool"}}</label>
             <input class="settings" type="checkbox" id="set_linkbodytohealth" name="data.settings.prefs.linkBodyToHealth" {{checked data.settings.prefs.linkBodyToHealth}}>
-            <label class="cpr-center settings-item settings clickable" style="width: 75px;" for="set_linkbodytohealth">{{localize "CPRED.linktobod"}}</label>
+            <label class="cpr-center settings-item settings clickable" style="width: 75px; height: 23px;" for="set_linkbodytohealth">{{localize "CPRED.linktobod"}}</label>
             <div class="resource-content flexrow flex-center flex-between">
               <input type="text" name="data.combatstats.healthpool.value" value="{{data.combatstats.healthpool.value}}" data-dtype="Number"/>
               <span> / </span>


### PR DESCRIPTION
This explicitly sets the height of the "Link to BOD" button on the NPC sheet, as it was not being set properly on some clients which causes some graphical glitches like health pool boxes overlapping other components.