### PR TITLE
use old cpr die handler to unbreak things

### DIFF
--- a/module/actor.js
+++ b/module/actor.js
@@ -795,14 +795,10 @@ export class cyberpunkredActor extends Actor {
         templateData.rollcpr = r;
         renderTemplate(template, templateData).then(content => {
           chatData.content = content;
-          //We use this call for dice3d if the roll is:
-          // Damage
-          // and the roll is not
-          // a NPC roll with GMAlwaysWhisper turned on
+          // Don't call dice-so-nice if this is an NPC roll with "Always Whisper NPC rolls on"
           if (game.dice3d && !(game.settings.get("cyberpunkred", "GMAlwaysWhisper") && actorData.type == "npc")) {
             game.dice3d.showForRoll(roll, chatData.whisper, chatData.blind).then(displayed => ChatMessage.create(chatData));
           } else {
-          // Dice3d is called by the skill roll handler in die-handler.js
             chatData.sound = CONFIG.sounds.dice;
             ChatMessage.create(chatData);
           }

--- a/module/actor.js
+++ b/module/actor.js
@@ -799,7 +799,7 @@ export class cyberpunkredActor extends Actor {
           // Damage
           // and the roll is not
           // a NPC roll with GMAlwaysWhisper turned on
-          if (rollType == "Damage" && game.dice3d && !(game.settings.get("cyberpunkred", "GMAlwaysWhisper") && actorData.type == "npc")) {
+          if (game.dice3d && !(game.settings.get("cyberpunkred", "GMAlwaysWhisper") && actorData.type == "npc")) {
             game.dice3d.showForRoll(roll, chatData.whisper, chatData.blind).then(displayed => ChatMessage.create(chatData));
           } else {
           // Dice3d is called by the skill roll handler in die-handler.js

--- a/module/settings.js
+++ b/module/settings.js
@@ -20,9 +20,9 @@ export const registerSystemSettings = function() {
     hint: "CPRED.dierollcommandhint",
     scope: "world",
     config: true,
-    default: "1dlcpred",
+    default: "dp",
     choices: {
-      "1dlcpred": "CPRED Core Rulebook Handler"
+      "dp": "CPRED Core Rulebook Handler"
     },
     type: String
   });


### PR DESCRIPTION
This switches to the original die handler that now correctly handles crit success/failures, but disables infinite explosions. 